### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.knavalbattle.json
+++ b/org.kde.knavalbattle.json
@@ -13,6 +13,14 @@
         "--socket=wayland",
         "--socket=pulseaudio"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/qml",
+        "/share/carddecks",
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "libkdegames",


### PR DESCRIPTION
KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.

This PR also removes the /share/carddecks folder, which is not required for this game.